### PR TITLE
✨ Deploy pre-built image using local or ecr 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Continuously deliver your applications to [BalenaCloud](https://www.balena.io/).
 
 ### `api-token`
 
-**Required**: A BalenaCloud API Token, used to authenticate with BalenaCloud.  API keys can be created in the [user settings for BalenaCloud](https://dashboard.balena-cloud.com/preferences/access-tokens).
+**Required**: A BalenaCloud API Token, used to authenticate with BalenaCloud. API keys can be created in the [user settings for BalenaCloud](https://dashboard.balena-cloud.com/preferences/access-tokens).
 
 ### `application-name`
 
@@ -14,13 +14,50 @@ Continuously deliver your applications to [BalenaCloud](https://www.balena.io/).
 
 ### `application-path`
 
-_Optional_: Provide a sub-path to the location for application being deployed to BalenaCloud.  Defaults to the workspace root.   
+_Optional_: Provide a sub-path to the location for application being deployed to BalenaCloud. Defaults to the workspace root.
 
 ### `version`
 
 _Optional_: Provide a version for the release being deployed to BalenaCloud. Defaults to 0.0.0.
 
+### `draft`
+
+_Optional_: Mark the release as draft. Defaults to false.
+
+## Registry Secrets
+
+This action supports pulling from private Docker registries by providing registry credentials. You can specify credentials in several ways:
+
+### Direct YAML/JSON Format
+
+### `registry-secrets-yaml`
+
+_Optional_: Registry secrets in YAML format. Takes precedence over other registry inputs.
+
+### `registry-secrets-json`
+
+_Optional_: Registry secrets in JSON format. Takes precedence over YAML and other registry inputs.
+
+### Simplified Registry Inputs
+
+### `registry-urls`
+
+_Optional_: Comma-separated list of registry URLs. Use empty string for Docker Hub, 'nvcr.io' for NVIDIA registry.
+
+### `registry-usernames`
+
+_Optional_: Comma-separated list of usernames corresponding to registry URLs.
+
+### `registry-passwords`
+
+_Optional_: Comma-separated list of passwords/tokens corresponding to registry URLs.
+
+**Note**: All three inputs (`registry-urls`, `registry-usernames`, `registry-passwords`) must have the same number of comma-separated values.
+
 ## Workflow Example
+
+### Basic Usage
+
 ```yaml
 name: BalenaCloud Push
 
@@ -34,11 +71,87 @@ jobs:
   balena-push:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: amingilani/push-to-balenacloud@v1.0.1
-      with:
-        api-token: ${{secrets.BALENA_API_TOKEN}}
-        application-name: ${{secrets.BALENA_APPLICATION_NAME}}
-        application-path: "./balena-wpe"
-        version: 1.0.0
+      - uses: actions/checkout@v1
+      - uses: amingilani/push-to-balenacloud@v1.0.1
+        with:
+          api-token: ${{secrets.BALENA_API_TOKEN}}
+          application-name: ${{secrets.BALENA_APPLICATION_NAME}}
+          application-path: "./balena-wpe"
+          version: 1.0.0
+```
+
+### With NVIDIA Container Registry (nvcr.io)
+
+```yaml
+name: BalenaCloud Push with NVCR
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  balena-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: polyperception/push-to-balenacloud@v1.2.5
+        with:
+          api-token: ${{secrets.BALENA_API_TOKEN}}
+          application-name: ${{secrets.BALENA_APPLICATION_NAME}}
+          registry-urls: "nvcr.io"
+          registry-usernames: ${{secrets.NVCR_USERNAME}}
+          registry-passwords: ${{secrets.NVCR_PASSWORD}}
+```
+
+### With Multiple Registries
+
+```yaml
+name: BalenaCloud Push with Multiple Registries
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  balena-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: polyperception/push-to-balenacloud@v1.2.5
+        with:
+          api-token: ${{secrets.BALENA_API_TOKEN}}
+          application-name: ${{secrets.BALENA_APPLICATION_NAME}}
+          registry-urls: ",nvcr.io,my-registry.com:5000"
+          registry-usernames: "${{secrets.DOCKERHUB_USERNAME}},${{secrets.NVCR_USERNAME}},${{secrets.CUSTOM_REGISTRY_USERNAME}}"
+          registry-passwords: "${{secrets.DOCKERHUB_PASSWORD}},${{secrets.NVCR_PASSWORD}},${{secrets.CUSTOM_REGISTRY_PASSWORD}}"
+```
+
+### With Direct YAML Registry Secrets
+
+```yaml
+name: BalenaCloud Push with YAML Registry Secrets
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  balena-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: amingilani/push-to-balenacloud@v1.0.1
+        with:
+          api-token: ${{secrets.BALENA_API_TOKEN}}
+          application-name: ${{secrets.BALENA_APPLICATION_NAME}}
+          registry-secrets-yaml: |
+            'nvcr.io':
+              username: ${{secrets.NVCR_USERNAME}}
+              password: ${{secrets.NVCR_PASSWORD}}
+            '':  # Docker Hub
+              username: ${{secrets.DOCKERHUB_USERNAME}}
+              password: ${{secrets.DOCKERHUB_PASSWORD}}
 ```

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,22 @@ inputs:
   draft:
     description: "Mark as draft release"
     required: false
-    default: 'false'
+    default: "false"
+  registry-secrets-yaml:
+    description: "Optional. Registry secrets in YAML format. Takes precedence over other registry inputs."
+    required: false
+  registry-secrets-json:
+    description: "Optional. Registry secrets in JSON format. Takes precedence over YAML and other registry inputs."
+    required: false
+  registry-urls:
+    description: "Optional. Comma-separated list of registry URLs. Use empty string for Docker Hub, 'nvcr.io' for NVIDIA registry."
+    required: false
+  registry-usernames:
+    description: "Optional. Comma-separated list of usernames corresponding to registry URLs."
+    required: false
+  registry-passwords:
+    description: "Optional. Comma-separated list of passwords/tokens corresponding to registry URLs."
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -29,3 +44,8 @@ runs:
     APPLICATION_PATH: ${{ inputs.application-path }}
     VERSION: ${{ inputs.version }}
     DRAFT: ${{ inputs.draft }}
+    REGISTRY_SECRETS_YAML: ${{ inputs.registry-secrets-yaml }}
+    REGISTRY_SECRETS_JSON: ${{ inputs.registry-secrets-json }}
+    REGISTRY_URLS: ${{ inputs.registry-urls }}
+    REGISTRY_USERNAMES: ${{ inputs.registry-usernames }}
+    REGISTRY_PASSWORDS: ${{ inputs.registry-passwords }}

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,11 @@ inputs:
   api-token:
     description: "BalenaCloud API Key"
     required: true
-  application-name:
-    description: "The name of the BalenaCloud Application that you'll be pushing to"
+  fleet-name:
+    description: "The name of the BalenaCloud Fleet that you'll be pushing to"
+    required: true
+  docker-image-name:
+    description: "The name of the local Docker image that you'll be pushing to"
     required: true
   application-path:
     description: "Optional. Provide a subfolder path to your BalenaCloud application, example: ./balena-wpe"
@@ -19,13 +22,14 @@ inputs:
   draft:
     description: "Mark as draft release"
     required: false
-    default: 'false'
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"
   env:
     API_TOKEN: ${{ inputs.api-token }}
-    APPLICATION_NAME: ${{ inputs.application-name }}
     APPLICATION_PATH: ${{ inputs.application-path }}
+    FLEET_NAME: ${{ inputs.fleet-name }}
+    DOCKER_IMAGE_NAME: ${{ inputs.docker-image-name }}
     VERSION: ${{ inputs.version }}
     DRAFT: ${{ inputs.draft }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash -o pipefail
 
-EXTRA_ARGS=""
+EXTRA_ARGS=" --debug --tag ${VERSION}"
 
 if [[ "${DRAFT}" == "true" ]]; then
-  EXTRA_ARGS="--draft"
+  EXTRA_ARGS="${EXTRA_ARGS} --draft"
 fi
 
-cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} && echo -e "name: ${APPLICATION_NAME}\ntype: sw.application\nversion: ${VERSION}" > balena.yml && /balena/bin//balena login --token ${API_TOKEN} && /balena/bin/balena push ${APPLICATION_NAME} ${EXTRA_ARGS} | grep -v \\[=*\>
+cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} \
+  && /balena/bin//balena login --token ${API_TOKEN} \
+  && /balena/bin/balena deploy ${FLEET_NAME} ${DOCKER_IMAGE_NAME} ${EXTRA_ARGS} | grep -v \\[=*\> 
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,6 @@ if [[ "${DRAFT}" == "true" ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} --draft"
 fi
 
-echo ${API_TOKEN}
-
 cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} \
   && echo -e "name: ${FLEET_NAME}\ntype: sw.application\nversion: ${VERSION}" > balena.yml \
   && /balena/bin//balena login --token ${API_TOKEN} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,13 @@
 #!/bin/bash -o pipefail
 
-EXTRA_ARGS=" --debug --release-tag ${VERSION}"
+EXTRA_ARGS=" --debug"
 
 if [[ "${DRAFT}" == "true" ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} --draft"
 fi
 
 cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} \
+  && echo -e "name: ${FLEET_NAME}\ntype: sw.application\nversion: ${VERSION}" > balena.yml \
   && /balena/bin//balena login --token ${API_TOKEN} \
   && /balena/bin/balena deploy ${FLEET_NAME} ${DOCKER_IMAGE_NAME} ${EXTRA_ARGS} | grep -v \\[=*\> 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,5 @@ fi
 cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} \
   && echo -e "name: ${FLEET_NAME}\ntype: sw.application\nversion: ${VERSION}" > balena.yml \
   && /balena/bin//balena login --token ${API_TOKEN} \
-  && /balena/bin/balena deploy ${FLEET_NAME} ${DOCKER_IMAGE_NAME} ${EXTRA_ARGS} | grep -v \\[=*\> 
+  && /balena/bin/balena deploy ${FLEET_NAME} --build --cache-from=${DOCKER_IMAGE_NAME} --tag=${VERSION} ${EXTRA_ARGS} | grep -v \\[=*\> 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,8 @@ if [[ "${DRAFT}" == "true" ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} --draft"
 fi
 
+echo ${API_TOKEN}
+
 cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} \
   && echo -e "name: ${FLEET_NAME}\ntype: sw.application\nversion: ${VERSION}" > balena.yml \
   && /balena/bin//balena login --token ${API_TOKEN} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,78 @@
 #!/bin/bash -o pipefail
 
 EXTRA_ARGS=""
+REGISTRY_SECRETS_FILE=""
 
 if [[ "${DRAFT}" == "true" ]]; then
   EXTRA_ARGS="--draft"
+fi
+
+# Handle registry secrets
+if [[ -n "${REGISTRY_SECRETS_JSON}" ]]; then
+  # Use provided JSON directly
+  echo "Using provided registry secrets JSON"
+  REGISTRY_SECRETS_FILE="/tmp/registry-secrets.json"
+  echo "${REGISTRY_SECRETS_JSON}" > "${REGISTRY_SECRETS_FILE}"
+elif [[ -n "${REGISTRY_SECRETS_YAML}" ]]; then
+  # Use provided YAML directly
+  echo "Using provided registry secrets YAML"
+  REGISTRY_SECRETS_FILE="/tmp/registry-secrets.yml"
+  echo "${REGISTRY_SECRETS_YAML}" > "${REGISTRY_SECRETS_FILE}"
+elif [[ -n "${REGISTRY_URLS}" && -n "${REGISTRY_USERNAMES}" && -n "${REGISTRY_PASSWORDS}" ]]; then
+  # Build registry secrets from comma-separated inputs
+  echo "Creating registry secrets from comma-separated inputs"
+  
+  # Convert comma-separated strings to arrays
+  IFS=',' read -ra URLS <<< "${REGISTRY_URLS}"
+  IFS=',' read -ra USERNAMES <<< "${REGISTRY_USERNAMES}"
+  IFS=',' read -ra PASSWORDS <<< "${REGISTRY_PASSWORDS}"
+  
+  # Check that arrays have the same length
+  if [[ ${#URLS[@]} -ne ${#USERNAMES[@]} || ${#URLS[@]} -ne ${#PASSWORDS[@]} ]]; then
+    echo "Error: registry-urls, registry-usernames, and registry-passwords must have the same number of comma-separated values"
+    exit 1
+  fi
+  
+  REGISTRY_SECRETS_CONTENT=""
+  
+  # Build YAML content from arrays
+  for i in "${!URLS[@]}"; do
+    url="${URLS[$i]}"
+    username="${USERNAMES[$i]}"
+    password="${PASSWORDS[$i]}"
+    
+    # Skip if any value is empty (except URL which can be empty for Docker Hub)
+    if [[ -z "${username}" || -z "${password}" ]]; then
+      echo "Warning: Skipping registry entry ${i} due to empty username or password"
+      continue
+    fi
+    
+    # Use empty string for Docker Hub, otherwise use the URL
+    if [[ -z "${url}" ]]; then
+      REGISTRY_SECRETS_CONTENT+="'':  # Docker Hub
+  username: ${username}
+  password: ${password}
+"
+    else
+      REGISTRY_SECRETS_CONTENT+="'${url}':
+  username: ${username}
+  password: ${password}
+"
+    fi
+  done
+  
+  # Create registry secrets file if we have any content
+  if [[ -n "${REGISTRY_SECRETS_CONTENT}" ]]; then
+    REGISTRY_SECRETS_FILE="/tmp/registry-secrets.yml"
+    echo "${REGISTRY_SECRETS_CONTENT}" > "${REGISTRY_SECRETS_FILE}"
+    echo "Registry secrets file created with ${#URLS[@]} registries"
+  fi
+fi
+
+# Add registry secrets argument if we have a secrets file
+if [[ -n "${REGISTRY_SECRETS_FILE}" ]]; then
+  EXTRA_ARGS="${EXTRA_ARGS} --registry-secrets ${REGISTRY_SECRETS_FILE}"
+  echo "Registry secrets file created at: ${REGISTRY_SECRETS_FILE}"
 fi
 
 cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} && echo -e "name: ${APPLICATION_NAME}\ntype: sw.application\nversion: ${VERSION}" > balena.yml && /balena/bin//balena login --token ${API_TOKEN} && /balena/bin/balena push ${APPLICATION_NAME} ${EXTRA_ARGS} | grep -v \\[=*\>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -o pipefail
 
-EXTRA_ARGS=" --debug --tag ${VERSION}"
+EXTRA_ARGS=" --debug --release-tag ${VERSION}"
 
 if [[ "${DRAFT}" == "true" ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} --draft"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,5 @@ fi
 cd ${GITHUB_WORKSPACE} && cd ${APPLICATION_PATH} \
   && echo -e "name: ${FLEET_NAME}\ntype: sw.application\nversion: ${VERSION}" > balena.yml \
   && /balena/bin//balena login --token ${API_TOKEN} \
-  && /balena/bin/balena deploy ${FLEET_NAME} --build --cache-from=${DOCKER_IMAGE_NAME} --tag=${VERSION} ${EXTRA_ARGS} | grep -v \\[=*\> 
+  && /balena/bin/balena deploy ${FLEET_NAME} ${DOCKER_IMAGE_NAME} ${EXTRA_ARGS} | grep -v \\[=*\> 
 


### PR DESCRIPTION
- Use balena deploy instead of balena push.
- No rebuild of the docker image (!!). Final image needs to be present on the runner or in any cloud registry
- To use cloud registry, specify url and credentials using
registry-urls:
registry-usernames:
registry-passwords:
OR
registry-secrets-yaml:
OR
registry-secrets-json:
Look into [balena doc](https://docs.balena.io/reference/balena-cli/latest/#deploy) for more details about secrets file.